### PR TITLE
Resolve mismatch stubbings in CfEnvS3ProcessorUnitTest.java

### DIFF
--- a/src/test/java/de/hdi/cfenv/s3/CfEnvS3ProcessorUnitTest.java
+++ b/src/test/java/de/hdi/cfenv/s3/CfEnvS3ProcessorUnitTest.java
@@ -48,7 +48,7 @@ class CfEnvS3ProcessorUnitTest {
 
     @Test
     void testAcceptPathGetLabelReturnsTrue() {
-        when(cfService.existsByTagIgnoreCase("S2")).thenReturn(false);
+        when(cfService.existsByTagIgnoreCase("s3")).thenReturn(false);
         when(cfService.getLabel()).thenReturn("Label s3");
         when(cfService.getName()).thenReturn("any Name");
 
@@ -57,7 +57,7 @@ class CfEnvS3ProcessorUnitTest {
 
     @Test
     void testAcceptPathGetNameReturnsTrue() {
-        when(cfService.existsByTagIgnoreCase("S2")).thenReturn(false);
+        when(cfService.existsByTagIgnoreCase("s3")).thenReturn(false);
         when(cfService.getLabel()).thenReturn("any Label");
         when(cfService.getName()).thenReturn("S3 Name");
 
@@ -66,7 +66,7 @@ class CfEnvS3ProcessorUnitTest {
 
     @Test
     void testAcceptAllPathsReturnFalse() {
-        when(cfService.existsByTagIgnoreCase("S2")).thenReturn(false);
+        when(cfService.existsByTagIgnoreCase("s3")).thenReturn(false);
         when(cfService.getLabel()).thenReturn("any Label");
         when(cfService.getName()).thenReturn("S2 Name");
 
@@ -75,7 +75,7 @@ class CfEnvS3ProcessorUnitTest {
 
     @Test
     void testAcceptPathGetLabelReturnsNull() {
-        when(cfService.existsByTagIgnoreCase("S2")).thenReturn(false);
+        when(cfService.existsByTagIgnoreCase("s3")).thenReturn(false);
         when(cfService.getLabel()).thenReturn(null);
         when(cfService.getName()).thenReturn("S2 Name");
 
@@ -84,7 +84,7 @@ class CfEnvS3ProcessorUnitTest {
 
     @Test
     void testAcceptPathGetNameReturnsNull() {
-        when(cfService.existsByTagIgnoreCase("S2")).thenReturn(false);
+        when(cfService.existsByTagIgnoreCase("s3")).thenReturn(false);
         when(cfService.getLabel()).thenReturn("any Label");
         when(cfService.getName()).thenReturn(null);
 


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In tests `testAcceptPathGetLabelReturnsTrue`, `testAcceptPathGetNameReturnsTrue`, `testAcceptAllPathsReturnFalse`, `testAcceptPathGetLabelReturnsNull`, and `testAcceptPathGetNameReturnsNull`: 

* the `existsByTagIgnoreCase` method for the `cfService` object:
i) is stubbed with argument `"S2"`
ii) during test execution the method is actually called with argument `"s3"`, resulting in mismatch stubbings

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbings. Happy to modify the pull request based on your feedback.